### PR TITLE
update set-output commands; add catch for failed package discovery

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,5 +20,6 @@ Imports:
 Suggests:
     testthat (>= 3.0.0),
     desc,
-    remotes
+    remotes,
+    withr
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vise
 Title: Package Discovery and Management Based on 'renv'
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1458-7108"))
@@ -11,7 +11,7 @@ Description: The 'renv' package is a wonderful tool for managing projects that
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 URL: https://github.com/zkamvar/vise
 BugReports: https://github.com/zkamvar/vise/issues
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# vise 0.0.0.9001
+
+* `ci_update()` now sends output messages using GitHub's environment variable syntax
+* `ci_update()` will now attempt to re-try failed installations due to missing 
+  system requirements.
+* new function `ci_new_pkg_sysreqs()` will take a list of packages and attempt
+  to install their system dependencies.
+- `lock2desc()` now can also take in a description object in place of `lockfile`
+* First tracked version of {vise}

--- a/R/lock2desc.R
+++ b/R/lock2desc.R
@@ -19,13 +19,17 @@ lock2desc <- function(lockfile, desc = tempfile()) {
   } else {
     out <- desc
   }
-  lock <- asNamespace("renv")$lockfile(lockfile)
-  dat <- lock$data()$Packages
-  pkg <- names(dat)
-  versions <- paste("==", vapply(dat, function(p) p$Version, character(1)))
-  deps <- data.frame(type = "Imports", package = pkg, version = versions)
-  d <- desc::description$new("!new")
-  d$set_deps(deps)
+  if (inherits(lockfile, "description")) {
+    d <- lockfile
+  } else {
+    lock <- asNamespace("renv")$lockfile(lockfile)
+    dat <- lock$data()$Packages
+    pkg <- names(dat)
+    versions <- paste("==", vapply(dat, function(p) p$Version, character(1)))
+    deps <- data.frame(type = "Imports", package = pkg, version = versions)
+    d <- desc::description$new("!new")
+    d$set_deps(deps)
+  }
   d$write(file = out)
   out
 }

--- a/R/lock2desc.R
+++ b/R/lock2desc.R
@@ -1,8 +1,12 @@
 #' convert a lockfile to a description file
 #'
-#' @param lockfile the path to the renv lockfile
+#' By default, this will take in a lockfile or a desc object and convert it to 
+#' an equivalent DESCRIPTION file for use with packages that check for system
+#' dependencies.
+#'
+#' @param lockfile the path to the renv lockfile OR a [desc::description()] object.
 #' @param desc the path to the new description file
-#' @return desc
+#' @return the path to the new description file
 #'
 #' @export
 #' @examples

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -56,7 +56,7 @@ ci_sysreqs <- function(lockfile, execute = TRUE, sudo = TRUE, exclude = c("git",
 }
 
 ci_new_pkgs_sysreqs <- function(pkgs, ...) {
-  d <- desc::description("!new")
+  d <- desc::description$new("!new")
   for (pkg in pkgs) {
     d$set_dep(pkg$package)
   }

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -54,3 +54,11 @@ ci_sysreqs <- function(lockfile, execute = TRUE, sudo = TRUE, exclude = c("git",
   #nocov end
   return(reqs)
 }
+
+ci_new_pkgs_sysreq <- function(pkgs, ...) {
+  d <- desc::description("!new")
+  for (pkg in pkgs) {
+    d$set_dep(pkg$package)
+  }
+  ci_sysreqs(d, ...)
+}

--- a/R/sysreqs.R
+++ b/R/sysreqs.R
@@ -55,7 +55,7 @@ ci_sysreqs <- function(lockfile, execute = TRUE, sudo = TRUE, exclude = c("git",
   return(reqs)
 }
 
-ci_new_pkgs_sysreq <- function(pkgs, ...) {
+ci_new_pkgs_sysreqs <- function(pkgs, ...) {
   d <- desc::description("!new")
   for (pkg in pkgs) {
     d$set_dep(pkg$package)

--- a/R/update.R
+++ b/R/update.R
@@ -32,9 +32,11 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
 
   # Detect any new packages that entered the lesson --------------------
   cat("::group::Discovering new packages\n")
-  deps        <- renv::dependencies(library = lib)
   hydra       <- renv::hydrate(library = lib, update = FALSE)
-  print(hydra)
+  if (length(hydra$missing) && on_linux) { 
+    ci_new_pkgs_sysreqs(hydra$missing)
+    hydra     <- renv::hydrate(library = lib, update = FALSE)
+  }
   new_lock    <- renv::snapshot(library = lib, lockfile = lock)
   sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))
   if (length(sneaky_pkgs)) {

--- a/R/update.R
+++ b/R/update.R
@@ -32,7 +32,9 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
 
   # Detect any new packages that entered the lesson --------------------
   cat("::group::Discovering new packages\n")
+  deps        <- renv::dependencies(library = lib)
   hydra       <- renv::hydrate(library = lib, update = FALSE)
+  print(hydra)
   new_lock    <- renv::snapshot(library = lib, lockfile = lock)
   sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))
   if (length(sneaky_pkgs)) {

--- a/R/update.R
+++ b/R/update.R
@@ -80,10 +80,10 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
   # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
   cat("::group::Creating the output\n")
   the_report <- paste0(the_report, collapse = "%0A")
-  meow  <- function(...) cat(..., "\n", sep = "")
+  meow  <- function(name, ...) cat(name, "=", ..., "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
   meow(the_report)
-  meow("::set-output name=report::", the_report)
-  meow("::set-output name=n::", n)
-  meow("::set-output name=date::", as.character(Sys.Date()))
+  meow("report", the_report)
+  meow("n", n)
+  meow("date", as.character(Sys.Date()))
   cat("::endgroup::\n")
 }

--- a/R/update.R
+++ b/R/update.R
@@ -83,7 +83,7 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
   # Construct the output -----------------------------------------------
   # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
   cat("::group::Creating the output\n")
-  the_report <- paste0(the_report, collapse = "%0A")
+  the_report <- paste0(the_report, collapse = "\n")
   meow  <- function(name, ...) cat(name, "=", ..., "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
   meow(the_report)
   meow("report", the_report)

--- a/R/update.R
+++ b/R/update.R
@@ -92,7 +92,6 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
       cat(name, "=", thing, "\n", file = out, sep = "", append = TRUE)
     }
   }
-  meow(the_report)
   meow("report", the_report)
   meow("n", n)
   meow("date", as.character(Sys.Date()))

--- a/R/update.R
+++ b/R/update.R
@@ -32,10 +32,14 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
 
   # Detect any new packages that entered the lesson --------------------
   cat("::group::Discovering new packages\n")
-  hydra       <- renv::hydrate(library = lib, update = FALSE)
+  hydra <- renv::hydrate(library = lib, update = FALSE)
+  # if there are errors here, it might be because we did not account for them
+  # when enumerating the system requirements. This accounts for that by 
+  # attempting the sysreqs installation and then re-trying the hydration
   if (length(hydra$missing) && on_linux) { 
+    cat("Some packages failed installation... attempting to find system requirements\n")
     ci_new_pkgs_sysreqs(hydra$missing)
-    hydra     <- renv::hydrate(library = lib, update = FALSE)
+    hydra <- renv::hydrate(library = lib, update = FALSE)
   }
   new_lock    <- renv::snapshot(library = lib, lockfile = lock)
   sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))

--- a/R/update.R
+++ b/R/update.R
@@ -86,8 +86,8 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
   meow  <- function(name, thing) {
     out <- Sys.getenv("GITHUB_OUTPUT")
     if (length(thing) > 1L) {
-      cat(name, "<<EOF\n", sep = "", file = out, sep = "", append = TRUE)
-      cat(thing, "EOF", sep = "\n", file = out, sep = "\n", append = TRUE)
+      cat(name, "<<EOF\n", file = out, sep = "", append = TRUE)
+      cat(thing, "EOF", file = out, sep = "\n", append = TRUE)
     } else {
       cat(name, "=", thing, "\n", file = out, sep = "", append = TRUE)
     }

--- a/R/update.R
+++ b/R/update.R
@@ -84,7 +84,7 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
   # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
   cat("::group::Creating the output\n")
   the_report <- paste0(the_report, collapse = "%0A")
-  meow  <- function(name, ...) cat(name, "=", ..., "\n", sep = "", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+  meow  <- function(name, ...) cat(name, "=", ..., "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
   meow(the_report)
   meow("report", the_report)
   meow("n", n)

--- a/R/update.R
+++ b/R/update.R
@@ -83,8 +83,15 @@ ci_update <- function(profile = 'lesson-requirments', update = 'true', repos = N
   # Construct the output -----------------------------------------------
   # https://github.community/t/set-output-truncates-multiline-strings/16852/3?u=zkamvar
   cat("::group::Creating the output\n")
-  the_report <- paste0(the_report, collapse = "\n")
-  meow  <- function(name, ...) cat(name, "=", ..., "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+  meow  <- function(name, thing) {
+    out <- Sys.getenv("GITHUB_OUTPUT")
+    if (length(thing) > 1L) {
+      cat(name, "<<EOF\n", sep = "", file = out, sep = "", append = TRUE)
+      cat(thing, "EOF", sep = "\n", file = out, sep = "\n", append = TRUE)
+    } else {
+      cat(name, "=", thing, "\n", file = out, sep = "", append = TRUE)
+    }
+  }
   meow(the_report)
   meow("report", the_report)
   meow("n", n)

--- a/man/lock2desc.Rd
+++ b/man/lock2desc.Rd
@@ -7,15 +7,17 @@
 lock2desc(lockfile, desc = tempfile())
 }
 \arguments{
-\item{lockfile}{the path to the renv lockfile}
+\item{lockfile}{the path to the renv lockfile OR a \code{\link[desc:description]{desc::description()}} object.}
 
 \item{desc}{the path to the new description file}
 }
 \value{
-desc
+the path to the new description file
 }
 \description{
-convert a lockfile to a description file
+By default, this will take in a lockfile or a desc object and convert it to
+an equivalent DESCRIPTION file for use with packages that check for system
+dependencies.
 }
 \examples{
 lock <- system.file("renv.lock", package = "vise")


### PR DESCRIPTION
This updates set-output commands so that warnings don't keep popping up.

This also adds an extra step to package discovery when `renv::hydrate()` fails due to unmet system requirements. 
