### PR TITLE
`ci_update()` force snapshot to address carpentries/actions#88

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vise
 Title: Package Discovery and Management Based on 'renv'
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: 
     person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1458-7108"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# vise 0.0.0.9004
+
+* `ci_update()` now uses `renv::snapshot(force = TRUE)` to avoid spurious 
+  pre-flight validation errors (@zkamvar, #7)
+
 # vise 0.0.0.9003
 
 * This package now requires {renv} version 0.17.3 or greater.

--- a/R/update.R
+++ b/R/update.R
@@ -27,8 +27,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
   if (on_linux)
     options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
   renv::load()
-  # shh <- utils::capture.output(
-  print(renv::restore(library = lib, lockfile = lock))
+  rest <- renv::restore(library = lib, lockfile = lock)
   cat("::endgroup::\n")
 
   # Detect any new packages that entered the lesson --------------------
@@ -41,7 +40,6 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
       cat(e$message)
     }
   )
-  print(hydra)
   # if there are errors here, it might be because we did not account for them
   # when enumerating the system requirements. This accounts for that by 
   # attempting the sysreqs installation and then re-trying the hydration
@@ -50,7 +48,6 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
     ci_new_pkgs_sysreqs(hydra$missing)
     hydra <- renv::hydrate(library = lib, update = TRUE)
   }
-  print(hydra)
   # The first snapshot captures the packages that were added during hydrate and
   # it will also capture the packages that were removed in the prose
   snap_report <- utils::capture.output(new_lock <- renv::snapshot(library = lib, lockfile = lock, force = TRUE))
@@ -116,6 +113,5 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
   meow("report", the_report)
   meow("n", n)
   meow("date", as.character(Sys.Date()))
-  cat(Sys.getenv("GITHUB_OUTPUT"))
   cat("::endgroup::\n")
 }

--- a/R/update.R
+++ b/R/update.R
@@ -53,7 +53,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
   print(hydra)
   # The first snapshot captures the packages that were added during hydrate and
   # it will also capture the packages that were removed in the prose
-  snap_report <- utils::capture.output(new_lock <- renv::snapshot(library = lib, lockfile = lock))
+  snap_report <- utils::capture.output(new_lock <- renv::snapshot(library = lib, lockfile = lock, force = TRUE))
   snap_report <- snap_report[startsWith(trimws(snap_report), "-")]
 
   sneaky_pkgs <- setdiff(names(new_lock$Packages), names(current_lock$Packages))

--- a/R/update.R
+++ b/R/update.R
@@ -27,7 +27,8 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', repos = 
   if (on_linux)
     options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
   renv::load()
-  shh <- utils::capture.output(renv::restore(library = lib, lockfile = lock))
+  # shh <- utils::capture.output(
+  print(renv::restore(library = lib, lockfile = lock))
   cat("::endgroup::\n")
 
   # Detect any new packages that entered the lesson --------------------


### PR DESCRIPTION
I'm not sure exactly _why_ the snapshot was not validating, but I added `force = TRUE` to the snapshot and `ci_update()` was able to successfully update packages. 

This _should_ work for now. See https://github.com/carpentries/actions/issues/88 for details