### PR TITLE
Add skip_restore option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,16 @@
 Package: vise
 Title: Package Discovery and Management Based on 'renv'
-Version: 0.0.0.9004
-Authors@R:
-    person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = c("aut", "cre"),
-           comment = c(ORCID = "0000-0003-1458-7108"))
+Version: 0.0.1.9000
+Authors@R: c(
+    person(given = "Robert",
+           family = "Davey",
+           role = c("aut", "cre"),
+           email = "robertdavey@carpentries.org",
+           comment = c(ORCID = "0000-0002-5589-7754")),    
+    person("Zhian N.", "Kamvar", , "zkamvar@gmail.com", role = c("aut"),
+           comment = c(ORCID = "0000-0003-1458-7108")),
+    person()
+    )
 Description: The 'renv' package is a wonderful tool for managing projects that
   is extensible and reliable. Vise serves as an opinionated implementation of
   'renv' that provides an one-function interface to the hydrate, restore,
@@ -11,7 +18,7 @@ Description: The 'renv' package is a wonderful tool for managing projects that
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 URL: https://github.com/zkamvar/vise
 BugReports: https://github.com/zkamvar/vise/issues
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# vise 0.0.1.9000
+
+* `ci_update()` now accepts a skip_restore option to force lockfile updating
+  (@froggleston)
+
+
 # vise 0.0.0.9004
 
 * `ci_update()` now uses `renv::snapshot(force = TRUE)` to avoid spurious 

--- a/man/ci_update.Rd
+++ b/man/ci_update.Rd
@@ -4,13 +4,22 @@
 \alias{ci_update}
 \title{Update Packages in a {renv} lockfile in GitHub Actions}
 \usage{
-ci_update(profile = "lesson-requirements", update = "true", repos = NULL)
+ci_update(
+  profile = "lesson-requirements",
+  update = "true",
+  skip_restore = "false",
+  repos = NULL
+)
 }
 \arguments{
 \item{profile}{the profile of the renv project}
 
 \item{update}{a character vector of \code{'true'} (default) or \code{'false'}, which
 indicates whether or not the existing packages should be updated.}
+
+\item{skip_restore}{do not attempt to restore the renv.lock packages before hydration
+(this can be useful to update broken or very old packages, or when R updates and
+existing package versions cannot be restored)}
 
 \item{repos}{the repositories to use in the search.}
 }


### PR DESCRIPTION
Sometimes the renv package cache becomes too outdated, and the renv::restore() part of ci_update will fail.

In this case, we want to skip this restore step and go straight on to renv::hydrate() instead.