### PR TITLE
Implement bioconductor update force option

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -34,6 +34,11 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', skip_res
   should_skip_restore <- as.logical(toupper(skip_restore))
   if (should_skip_restore) {
     cat("Skipping restore at user request\n")
+
+    uses_bioc <- current_lock$Bioconductor
+    if (!is.null(uses_bioc)) {
+      renv::init(bioconductor = TRUE, profile = profile)
+    }
   }
   else {
     cat("::group::Restoring package library\n")


### PR DESCRIPTION
Currently, vise will not update bioconductor packages very effectively, leaving users to have to manually run local functions to do so. This option allows not only the previous restore skip to force lockfile updating, but now includes the step to re-init the lockfile with bioconductor packages, meaning the [6 month refresh loop](https://github.com/carpentries/sandpaper/issues/453) can be bypassed.

This is implemented in such a way that checking the requisite box in the manual workflow run step will perform this function if "Bioconductor" is supplied in the lockfile:

![{834077EE-D9B5-4587-8EE7-D1DCC4A5976E}](https://github.com/user-attachments/assets/b8f6bbb1-d94d-4e63-86ad-710415d366dd)

