### PR TITLE
Add forced package restore and update check

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -16,8 +16,8 @@ ci_package_update_check <- function(lib = lib) {
   updates <- renv::update(library = lib, check = TRUE)
   updates_needed <- !identical(updates, TRUE)
 
-  n <- 0
-  the_report <- character(0)
+  report_env$n <- 0
+  report_env$report <- character(0)
 
   if (updates_needed) {
     # apply the updates and run a snapshot if the dry run found updates
@@ -35,13 +35,13 @@ ci_package_update_check <- function(lib = lib) {
     # renv::update(check = TRUE) no longer gives us an accurate count because
     # it also counts packages that were accidentally inserted.
     n_updates <- sum(startsWith(trimws(snapshot_report), "-"))
-    report_env$n <- n + n_updates
-    report_env$report <- c(the_report, snapshot_report)
+    report_env$n <- report_env$n + n_updates
+    report_env$report <- c(report_env$report, snapshot_report)
     cat("Updating", n_updates, "packages", "\n")
     cat("::endgroup::\n")
   }
 
-  return(report_env)
+  invisible(report_env)
 }
 
 #' Update Packages in a {renv} lockfile in GitHub Actions

--- a/R/update.R
+++ b/R/update.R
@@ -1,3 +1,49 @@
+ci_parse_snapshot_report <- function(snapshot_report) {
+  header <- which(startsWith(trimws(snapshot_report), "#"))
+  if (length(header)) {
+    header <- seq(min(header) - 1L)
+  }
+  footer <- tryCatch(seq(which(startsWith(trimws(snapshot_report), "- Lockfile")),
+  length(snapshot_report)), error = function(e) length(snapshot_report))
+  snapshot_report <- snapshot_report[-c(header, footer)]
+  invisible(snapshot_report)
+}
+
+ci_package_update_check <- function(lib = lib) {
+  report_env = env()
+
+  cat("::group::CI Package Update Check\n")
+  updates <- renv::update(library = lib, check = TRUE)
+  updates_needed <- !identical(updates, TRUE)
+
+  n <- 0
+  the_report <- character(0)
+
+  if (updates_needed) {
+    # apply the updates and run a snapshot if the dry run found updates
+    renv::update(library = lib)
+
+    # The update report has some noise from the snapshot, so we need to clean
+    # it up by removing the header (that starts before the `# CRAN` signifier)
+    # and the footer that starts with ` - Lockfile written to`
+    snapshot_report <- ci_parse_snapshot_report(
+      utils::capture.output(renv::snapshot(lockfile = lock, prompt = FALSE))
+    )
+
+    # We can detect the number of updated packages via checking the number of
+    # ticks the output has. This is crude, but the updates from
+    # renv::update(check = TRUE) no longer gives us an accurate count because
+    # it also counts packages that were accidentally inserted.
+    n_updates <- sum(startsWith(trimws(snapshot_report), "-"))
+    report_env$n <- n + n_updates
+    report_env$report <- c(the_report, snapshot_report)
+    cat("Updating", n_updates, "packages", "\n")
+    cat("::endgroup::\n")
+  }
+
+  return(report_env)
+}
+
 #' Update Packages in a {renv} lockfile in GitHub Actions
 #'
 #' With actively developed projects, it can be beneficial to auto-update
@@ -19,10 +65,6 @@
 #' @param repos the repositories to use in the search.
 #' @export
 ci_update <- function(profile = 'lesson-requirements', update = 'true', force_renv_init = 'false', repos = NULL) {
-
-  n <- 0
-  the_report <- character(0)
-
   Sys.setenv("RENV_PROFILE" = profile)
   lib  <- renv::paths$library()
   lock <- renv::paths$lockfile()
@@ -33,6 +75,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
   if (on_linux)
     options(repos = c(RSPM = Sys.getenv("RSPM"), getOption("repos")))
   renv::load()
+
+  n <- 0
+  the_report <- character(0)
 
   should_force_renv_init <- as.logical(toupper(force_renv_init))
   should_update <- as.logical(toupper(update))
@@ -72,8 +117,11 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         cat("::endgroup::\n")
 
         cat("::group::Updating lockfile\n")
-        renv::snapshot(prompt = FALSE)
+        snapshot_report <- ci_parse_snapshot_report(
+          utils::capture.output(renv::snapshot(lockfile = lock, prompt = FALSE))
+        )
         cat("::endgroup::\n")
+        n <- n + sum(startsWith(trimws(snapshot_report), "-"))
 
         "repaired"
       })
@@ -146,36 +194,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
   # Check for updates to packages --------------------------------------
   if (should_update) {
-    cat("::group::Applying Updates\n")
-    updates <- renv::update(library = lib, check = TRUE)
-    updates_needed <- !identical(updates, TRUE)
-  } else {
-    updates_needed <- FALSE
-  }
-  if (updates_needed) {
-    # apply the updates and run a snapshot if the dry run found updates
-    renv::update(library = lib)
-    # The update report has some noise from the snapshot, so we need to clean
-    # it up by removing the header (that starts before the `# CRAN` signifier)
-    # and the footer that starts with ` - Lockfile written to`
-    update_report <- utils::capture.output(renv::snapshot(lockfile = lock))
-    header <- which(startsWith(trimws(update_report), "#"))
-    if (length(header)) {
-      header <- seq(min(header) - 1L)
-    }
-    footer <- tryCatch(seq(which(startsWith(trimws(update_report), "- Lockfile")),
-    length(update_report)), error = function(e) length(update_report))
-    update_report <- update_report[-c(header, footer)]
-
-    # We can detect the number of updated packages via checking the number of
-    # ticks the output has. This is crude, but the updates from
-    # renv::update(check = TRUE) no longer gives us an accurate count because
-    # it also counts packages that were accidentally inserted.
-    n_updates <- sum(startsWith(trimws(update_report), "-"))
-    n <- n + n_updates
-    the_report <- c(the_report, update_report)
-    cat("Updating", n_updates, "packages", "\n")
-    cat("::endgroup::\n")
+    update_report <- ci_package_update_check(lib = lib)
+    the_report <- c(the_report, update_report$report)
+    n <- update_report$n + n
   }
 
   cat("::group::Cleaning the cache\n")

--- a/R/update.R
+++ b/R/update.R
@@ -94,7 +94,10 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       restore_output <- character(0)
       updated <- tryCatch({
         restore_output <<- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
-        new.env(n = 0, report = restore_output)
+        restore_env <- new.env()
+        restore_env$n = 0
+        restore_env$report = restore_output
+        restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         failed_restore_output <- grepl("^- \\[.+\\]: install failed", restore_output, value = TRUE)
@@ -128,7 +131,10 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
         )
         cat("::endgroup::\n")
-        new.env(n = n, report = c(failed_report, install_result, snapshot_report))
+        restore_env <- new.env()
+        restore_env$n = n
+        restore_env$report = c(failed_report, install_result, snapshot_report)
+        restore_env
       })
     }
 

--- a/R/update.R
+++ b/R/update.R
@@ -105,14 +105,12 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         pkgs <- names(current_lock$Packages)
 
         cat("Updating", length(pkgs), "packages from current CRAN\n")
-        install_result <- tryCatch({
-          renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary")
-          TRUE
+        tryCatch({
+          install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary")
         }, error = function(e2) {
           cat("Binary install failed, trying with source allowed:\n")
           cat(conditionMessage(e2), "\n")
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
-          TRUE
         })
         if (!is.null(install_result)) {
           n <- n + length(install_result)
@@ -199,7 +197,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
   if (should_update) {
     update_report <- ci_package_update_check(lib = lib)
     the_report <- c(the_report, update_report$report)
-    n <- update_report$n + n
+    n <- n + update_report$n
   }
 
   cat("::group::Cleaning the cache\n")

--- a/R/update.R
+++ b/R/update.R
@@ -48,10 +48,29 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = TRUE)
       "success"
     }, error = function(e) {
-      cat("Restore failed, attempting repair\n")
-      pkgs <- names(lock$Packages)
-      renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
+      cat("Restore failed:", conditionMessage(e), "\n")
+      cat("Attempting repair by updating packages to latest CRAN versions\n")
+
+      # Force current CRAN (not lockfile snapshots)
+      options(repos = c(CRAN = "https://cloud.r-project.org"))
+      options(pkgType = "binary")  # Prefer binaries
+
+      pkgs <- names(current_lock$Packages)
+
+      cat("Updating", length(pkgs), "packages from current CRAN\n")
+      install_result <- tryCatch({
+        renv::install(pkgs, prompt = FALSE, rebuild = FALSE, type = "binary")
+        TRUE
+      }, error = function(e2) {
+        cat("Binary install failed, trying with source allowed:\n")
+        cat(conditionMessage(e2), "\n")
+        renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
+        TRUE
+      })
+
+      cat("Updating lockfile\n")
       renv::snapshot(prompt = FALSE)
+
       "repaired"
     })
   }

--- a/R/update.R
+++ b/R/update.R
@@ -38,8 +38,7 @@ ci_package_update_check <- function(lib, lockfile) {
     # it up by removing the header (that starts before the `# CRAN` signifier)
     # and the footer that starts with ` - Lockfile written to`
     snapshot_report <- ci_parse_snapshot_report_packages(
-      utils::capture.output(renv::snapshot(lockfile = lockfile, library = lib, prompt = FALSE)),
-      snapshot = TRUE
+      utils::capture.output(renv::snapshot(lockfile = lockfile, library = lib, prompt = FALSE))
     )
 
     # We can detect the number of updated packages via checking the number of

--- a/R/update.R
+++ b/R/update.R
@@ -94,7 +94,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       restore_output <- character(0)
       updated <- tryCatch({
         restore_output <<- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
-        restore_env <- new.env(n = 0, report = restore_output)
+        restore_env <- new.env()
+        restore_env$n = 0
+        restore_env$report = restore_output
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
@@ -131,7 +133,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
             utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
           )
           cat("::endgroup::\n")
-          restore_env <- new.env(n = 0, report = c(failed_report, install_result, snapshot_report))
+          restore_env <- new.env()
+          restore_env$n = n
+          restore_env$report = c(failed_report, install_result, snapshot_report)
           restore_env
         }
       })

--- a/R/update.R
+++ b/R/update.R
@@ -94,48 +94,46 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       restore_output <- character(0)
       updated <- tryCatch({
         restore_output <<- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
-        restore_env <- new.env()
-        restore_env$n = 0
-        restore_env$report = restore_output
+        restore_env <- new.env(n = 0, report = restore_output)
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
-        restore_output <- strsplit(restore_output, "\n")[[1]]
-        failed_restore_output <- grep("^[[:space:]]+- \\[.+\\]: install failed", restore_output, value = TRUE)
-        n_failed_restore <- length(failed_restore_output)
+        failmsg <-strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
+        if (length(failmsg) >= 0) {
+          failed_restore_output <- gsub("\"", "", trimws(failmsg[[1]]))
+          n_failed_restore <- length(failed_restore_output)
 
-        failed_report <- "The following packages failed to restore:\n\n"
-        failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"), "\n\n")
+          failed_report <- "The following packages failed to restore:\n\n"
+          failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"), "\n\n", "Attempting to update these packages to the latest CRAN versions.\n\n")
 
-        cat("::group::Attempting repair by updating", n_failed_restore, "packages to latest CRAN versions\n")
+          cat("::group::Attempting repair by updating", n_failed_restore, "packages to latest CRAN versions\n")
 
-        # Use CRAN instead of lockfile RSPM snapshots, preferring binaries
-        options(repos = c(CRAN = "https://cloud.r-project.org", RSPM = Sys.getenv("RSPM")))
-        options(pkgType = "binary")
+          # Use CRAN instead of lockfile RSPM snapshots, preferring binaries
+          options(repos = c(CRAN = "https://cloud.r-project.org", RSPM = Sys.getenv("RSPM")))
+          options(pkgType = "binary")
 
-        pkgs <- names(current_lock$Packages)
+          pkgs <- names(current_lock$Packages)
 
-        install_result <- character(0)
-        cat("Updating", length(pkgs), "packages from current CRAN\n")
-        install_result <- tryCatch({
-          utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"), type = "message")
-        }, error = function(e2) {
-          cat("Binary install failed, trying with source allowed:\n")
-          cat(conditionMessage(e2), "\n")
-          utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
-        })
-        n <- n + sum(startsWith(trimws(install_result), "-"))
-        cat("::endgroup::\n")
+          install_result <- character(0)
+          cat("Updating", length(pkgs), "packages from current CRAN\n")
+          install_result <- tryCatch({
+            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"), type = "message")
+          }, error = function(e2) {
+            cat("Binary install failed, trying with source allowed:\n")
+            cat(conditionMessage(e2), "\n")
+            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
+          })
+          n <- n + sum(startsWith(trimws(install_result), "-"))
+          cat("::endgroup::\n")
 
-        cat("::group::Updating lockfile\n")
-        snapshot_report <- ci_parse_snapshot_report(
-          utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
-        )
-        cat("::endgroup::\n")
-        restore_env <- new.env()
-        restore_env$n = n
-        restore_env$report = c(failed_report, install_result, snapshot_report)
-        restore_env
+          cat("::group::Updating lockfile\n")
+          snapshot_report <- ci_parse_snapshot_report(
+            utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
+          )
+          cat("::endgroup::\n")
+          restore_env <- new.env(n = 0, report = c(failed_report, install_result, snapshot_report))
+          restore_env
+        }
       })
     }
 

--- a/R/update.R
+++ b/R/update.R
@@ -43,14 +43,17 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       renv::init(bioconductor = TRUE, profile = profile)
     }
 
-    rest <- renv::restore(library = lib, lockfile = lock)
-
-    cat("Forcing initial package update\n")
-    updates <- renv::update(library = lib, check = TRUE)
-    updates_needed <- !identical(updates, TRUE)
-    if (updates_needed) {
-      renv::update(library = lib, lock = TRUE)
-    }
+    cat("Forcing initial package restore check\n")
+    restore_result <- tryCatch({
+      renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = TRUE)
+      "success"
+    }, error = function(e) {
+      cat("Restore failed, attempting repair\n")
+      pkgs <- names(lock$Packages)
+      renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
+      renv::snapshot(prompt = FALSE)
+      "repaired"
+    })
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -91,14 +91,15 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
     if (should_update) {
       cat("Attempt initial package restore check\n")
-      tryCatch({
+      num_updated <- tryCatch({
         renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE)
+        0
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         cat("::group::Attempting repair by updating packages to latest CRAN versions\n")
 
         # Use CRAN instead of lockfile RSPM snapshots, preferring binaries
-        options(repos = c(CRAN = "https://cloud.r-project.org"))
+        options(repos = c(CRAN = "https://cloud.r-project.org", RSPM = Sys.getenv("RSPM")))
         options(pkgType = "binary")
 
         pkgs <- names(current_lock$Packages)
@@ -112,7 +113,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           cat(conditionMessage(e2), "\n")
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
         })
-        # n <- n + length(install_result)
+        n <- n + length(install_result)
 
         cat("::endgroup::\n")
 
@@ -121,12 +122,13 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
         )
         cat("::endgroup::\n")
-        n <- n + sum(startsWith(trimws(snapshot_report), "-"))
+        # n <- n + sum(startsWith(trimws(snapshot_report), "-"))
 
-        cat("Installed", n, "packages from current CRAN\n")
+        # cat("Installed", n, "packages from current CRAN\n")
+        n
       })
     }
-
+    n <- n + num_updated
     cat("Current count:", n, "\n")
   }
 

--- a/R/update.R
+++ b/R/update.R
@@ -94,15 +94,15 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       updated <- tryCatch({
         restore_output <- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
         restore_env <- new.env()
-        restore_env$n = 0
-        restore_env$report = restore_output
+        restore_env$n <- 0
+        restore_env$report <- restore_output
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         failmsg <- strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
         restore_env <- new.env()
-        restore_env$n = 0
-        restore_env$report = failmsg
+        restore_env$n <- 0
+        restore_env$report <- failmsg
 
         if (length(failmsg) > 0) {
           failed_restore_output <- gsub("\"", "", trimws(failmsg[[1]]))
@@ -132,11 +132,13 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           cat("::endgroup::\n")
 
           cat("::group::Updating lockfile\n")
-          snapshot_report <- utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE), type = "message")
+          snapshot_report <- ci_parse_snapshot_report(
+            utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE), type = "message")
+          )
           cat("::endgroup::\n")
 
-          restore_env$n = n_installed
-          restore_env$report = c(failed_report, install_result, snapshot_report)
+          restore_env$n <- n_installed
+          restore_env$report <- c(failed_report, install_result, snapshot_report)
 
           cat("Repaired", restore_env$n, "packages\n")
         }

--- a/R/update.R
+++ b/R/update.R
@@ -91,9 +91,8 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
     if (should_update) {
       cat("Attempt initial package restore check\n")
-      restore_result <- tryCatch({
+      tryCatch({
         renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE)
-        "success"
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         cat("::group::Attempting repair by updating packages to latest CRAN versions\n")
@@ -113,11 +112,10 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           cat(conditionMessage(e2), "\n")
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
         })
-        n <- n + length(install_result)
+        # n <- n + length(install_result)
 
         cat("::endgroup::\n")
 
-        cat("Installed", length(install_result), "packages from current CRAN\n")
         cat("::group::Updating lockfile\n")
         snapshot_report <- ci_parse_snapshot_report(
           utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
@@ -125,9 +123,11 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         cat("::endgroup::\n")
         n <- n + sum(startsWith(trimws(snapshot_report), "-"))
 
-        "repaired"
+        cat("Installed", n, "packages from current CRAN\n")
       })
     }
+
+    cat("Current count:", n, "\n")
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -20,7 +20,7 @@ ci_parse_install_report_packages <- function(install_report) {
   return(install_report_clean)
 }
 
-ci_package_update_check <- function(lib = lib) {
+ci_package_update_check <- function(lib, lockfile) {
   report_env = new.env()
 
   cat("::group::CI Package Update Check\n")
@@ -232,7 +232,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
   # Check for updates to packages --------------------------------------
   if (should_update) {
-    update_report <- ci_package_update_check(lib = lib)
+    update_report <- ci_package_update_check(lib, lock)
     the_report <- c(the_report, update_report$report)
     n <- n + update_report$n
   }

--- a/R/update.R
+++ b/R/update.R
@@ -100,6 +100,10 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         failmsg <-strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
+        restore_env <- new.env()
+        restore_env$n = 0
+        restore_env$report = failmsg
+
         if (length(failmsg) > 0) {
           failed_restore_output <- gsub("\"", "", trimws(failmsg[[1]]))
           n_failed_restore <- length(failed_restore_output)
@@ -132,14 +136,15 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
             utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
           )
           cat("::endgroup::\n")
-          restore_env <- new.env()
+
           restore_env$n = n
           restore_env$report = c(failed_report, install_result, snapshot_report)
-          restore_env
         }
+        restore_env
       })
       n <- n + updated$n
       the_report <- c(the_report, updated$report)
+      cat("Repaired", n, "packages\n")
     }
   }
 

--- a/R/update.R
+++ b/R/update.R
@@ -104,6 +104,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
         pkgs <- names(current_lock$Packages)
 
+        install_result <- character(0)
         cat("Updating", length(pkgs), "packages from current CRAN\n")
         tryCatch({
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary")
@@ -112,11 +113,11 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           cat(conditionMessage(e2), "\n")
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
         })
-        if (!is.null(install_result)) {
-          n <- n + length(install_result)
-        }
+        n <- n + length(install_result)
+
         cat("::endgroup::\n")
 
+        cat("Installed", length(install_result), "packages from current CRAN\n")
         cat("::group::Updating lockfile\n")
         snapshot_report <- ci_parse_snapshot_report(
           utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))

--- a/R/update.R
+++ b/R/update.R
@@ -1,4 +1,4 @@
-ci_parse_snapshot_report <- function(snapshot_report) {
+ci_parse_snapshot_report_packages <- function(snapshot_report) {
   header <- which(startsWith(trimws(snapshot_report), "#"))
   if (length(header)) {
     header <- seq(min(header) - 1L)
@@ -7,6 +7,17 @@ ci_parse_snapshot_report <- function(snapshot_report) {
   length(snapshot_report)), error = function(e) length(snapshot_report))
   snapshot_report_clean <- snapshot_report[-c(header, footer)]
   return(snapshot_report_clean)
+}
+
+ci_parse_install_report_packages <- function(install_report) {
+  header <- which(startsWith(trimws(install_report), "The following package(s) will be installed:"))
+  if (length(header)) {
+    header <- seq(min(header) - 1L)
+  }
+  footer <- tryCatch(seq(which(startsWith(trimws(install_report), "These packages will be installed into")),
+  length(install_report)), error = function(e) length(install_report))
+  install_report_clean <- install_report[-c(header, footer)]
+  return(install_report_clean)
 }
 
 ci_package_update_check <- function(lib = lib) {
@@ -26,8 +37,9 @@ ci_package_update_check <- function(lib = lib) {
     # The update report has some noise from the snapshot, so we need to clean
     # it up by removing the header (that starts before the `# CRAN` signifier)
     # and the footer that starts with ` - Lockfile written to`
-    snapshot_report <- ci_parse_snapshot_report(
-      utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
+    snapshot_report <- ci_parse_snapshot_report_packages(
+      utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE)),
+      snapshot = TRUE
     )
 
     # We can detect the number of updated packages via checking the number of
@@ -108,7 +120,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           failed_restore_output <- gsub("\"", "", trimws(failmsg[[1]]))
           n_failed_restore <- length(failed_restore_output)
 
-          failed_report <- "The following packages failed to restore:\n\n"
+          failed_report <- paste0("The following ", n_failed_restore, " packages failed to restore:\n\n")
           failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"), "\n\n", "Attempting to update these packages to the latest CRAN versions.\n\n")
 
           cat("::group::Attempting repair by updating", n_failed_restore, "packages to latest CRAN versions\n")
@@ -121,20 +133,26 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
           cat("Updating", length(pkgs), "packages from current CRAN\n")
           install_result <- tryCatch({
-            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"))
+            ci_parse_install_report_packages(
+              utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"))
+            )
           }, error = function(e2) {
             cat("Binary install failed, trying with source allowed:\n")
             cat(conditionMessage(e2), "\n")
-            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE))
+            ci_parse_install_report_packages(
+              utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE))
+            )
           })
           n_installed <- sum(startsWith(trimws(install_result), "-"))
           cat("::endgroup::\n")
 
           cat("::group::Updating lockfile\n")
-          snapshot_report <- ci_parse_snapshot_report(
-            utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE), type = "message")
+          snapshot_report <- ci_parse_snapshot_report_packages(
+            utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
           )
           cat("::endgroup::\n")
+
+          failed_report <- paste0(failed_report, paste0("Repaired ", restore_env$n, " packages successfully.\n"))
 
           restore_env$n <- n_installed
           restore_env$report <- c(failed_report, install_result, snapshot_report)

--- a/R/update.R
+++ b/R/update.R
@@ -119,14 +119,13 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
           pkgs <- names(current_lock$Packages)
 
-          install_result <- character(0)
           cat("Updating", length(pkgs), "packages from current CRAN\n")
           install_result <- tryCatch({
-            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"), type = "message")
+            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"))
           }, error = function(e2) {
             cat("Binary install failed, trying with source allowed:\n")
             cat(conditionMessage(e2), "\n")
-            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
+            utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE))
           })
           n_installed <- sum(startsWith(trimws(install_result), "-"))
           cat("::endgroup::\n")

--- a/R/update.R
+++ b/R/update.R
@@ -91,12 +91,19 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
     if (should_update) {
       cat("Attempt initial package restore check\n")
-      num_updated <- tryCatch({
-        renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE)
-        0
+      restore_output <- character(0)
+      updated <- tryCatch({
+        restore_output <<- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
+        new.env(n = 0, report = restore_output)
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
-        cat("::group::Attempting repair by updating packages to latest CRAN versions\n")
+        failed_restore_output <- grepl("^- \\[.+\\]: install failed", restore_output, value = TRUE)
+        n_failed_restore <- length(failed_restore_output)
+
+        failed_report <- "The following packages failed to restore:\n\n"
+        failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"))
+
+        cat("::group::Attempting repair by updating", n_failed_restore, "packages to latest CRAN versions\n")
 
         # Use CRAN instead of lockfile RSPM snapshots, preferring binaries
         options(repos = c(CRAN = "https://cloud.r-project.org", RSPM = Sys.getenv("RSPM")))
@@ -106,15 +113,14 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
         install_result <- character(0)
         cat("Updating", length(pkgs), "packages from current CRAN\n")
-        tryCatch({
-          install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary")
+        install_result <- tryCatch({
+          utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary"), type = "message")
         }, error = function(e2) {
           cat("Binary install failed, trying with source allowed:\n")
           cat(conditionMessage(e2), "\n")
-          install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
+          utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
         })
-        n <- n + length(install_result)
-
+        n <- n + sum(startsWith(trimws(install_result), "-"))
         cat("::endgroup::\n")
 
         cat("::group::Updating lockfile\n")
@@ -122,14 +128,12 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
         )
         cat("::endgroup::\n")
-        # n <- n + sum(startsWith(trimws(snapshot_report), "-"))
-
-        # cat("Installed", n, "packages from current CRAN\n")
-        n
+        new.env(n = n, report = c(failed_report, install_result, snapshot_report))
       })
     }
-    n <- n + num_updated
-    cat("Current count:", n, "\n")
+
+    n <- n + updated$n
+    the_report <- c(the_report, updated$report)
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -42,6 +42,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
     if (!is.null(uses_bioc)) {
       renv::init(bioconductor = TRUE, profile = profile)
     }
+
+    cat("Forcing initial package update\n")
+    renv::update(library = lib)
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -44,7 +44,11 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
     }
 
     cat("Forcing initial package update\n")
-    renv::update(library = lib)
+    updates <- renv::update(library = lib, check = TRUE)
+    updates_needed <- !identical(updates, TRUE)
+    if (updates_needed) {
+      renv::update(library = lib, lock = TRUE)
+    }
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -99,7 +99,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
-        failmsg <-strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
+        failmsg <- strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
         restore_env <- new.env()
         restore_env$n = 0
         restore_env$report = failmsg
@@ -128,7 +128,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
             cat(conditionMessage(e2), "\n")
             utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
           })
-          n <- sum(startsWith(trimws(install_result), "-"))
+          n_installed <- sum(startsWith(trimws(install_result), "-"))
           cat("::endgroup::\n")
 
           cat("::group::Updating lockfile\n")
@@ -137,7 +137,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           )
           cat("::endgroup::\n")
 
-          restore_env$n = n
+          restore_env$n = n_installed
           restore_env$report = c(failed_report, install_result, snapshot_report)
         }
         restore_env

--- a/R/update.R
+++ b/R/update.R
@@ -100,11 +100,12 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
-        failed_restore_output <- grep("^- \\[.+\\]: install failed", restore_output, value = TRUE)
+        restore_output <- strsplit(restore_output, "\n")[[1]]
+        failed_restore_output <- grep("^[[:space:]]+- \\[.+\\]: install failed", restore_output, value = TRUE)
         n_failed_restore <- length(failed_restore_output)
 
         failed_report <- "The following packages failed to restore:\n\n"
-        failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"))
+        failed_report <- paste0(failed_report, paste(failed_restore_output, collapse = "\n"), "\n\n")
 
         cat("::group::Attempting repair by updating", n_failed_restore, "packages to latest CRAN versions\n")
 

--- a/R/update.R
+++ b/R/update.R
@@ -100,7 +100,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
         restore_env
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
-        failed_restore_output <- grepl("^- \\[.+\\]: install failed", restore_output, value = TRUE)
+        failed_restore_output <- grep("^- \\[.+\\]: install failed", restore_output, value = TRUE)
         n_failed_restore <- length(failed_restore_output)
 
         failed_report <- "The following packages failed to restore:\n\n"

--- a/R/update.R
+++ b/R/update.R
@@ -114,6 +114,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
           TRUE
         })
+        if (!is.null(install_result)) {
+          n <- n + length(install_result)
+        }
         cat("::endgroup::\n")
 
         cat("::group::Updating lockfile\n")

--- a/R/update.R
+++ b/R/update.R
@@ -102,7 +102,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
     }
 
     if (should_update) {
-      cat("Attempt initial package restore check\n")
+      cat("Forcing package restore check\n")
       updated <- tryCatch({
         restore_output <- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
         restore_env <- new.env()
@@ -152,7 +152,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           )
           cat("::endgroup::\n")
 
-          failed_report <- paste0(failed_report, paste0("Repaired ", restore_env$n, " packages successfully.\n"))
+          failed_report <- paste0(failed_report, paste0("Repaired ", n_installed, " packages successfully.\n"))
 
           restore_env$n <- n_installed
           restore_env$report <- c(failed_report, install_result, snapshot_report)

--- a/R/update.R
+++ b/R/update.R
@@ -43,6 +43,8 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       renv::init(bioconductor = TRUE, profile = profile)
     }
 
+    rest <- renv::restore(library = lib, lockfile = lock)
+
     cat("Forcing initial package update\n")
     updates <- renv::update(library = lib, check = TRUE)
     updates_needed <- !identical(updates, TRUE)

--- a/R/update.R
+++ b/R/update.R
@@ -38,7 +38,7 @@ ci_package_update_check <- function(lib, lockfile) {
     # it up by removing the header (that starts before the `# CRAN` signifier)
     # and the footer that starts with ` - Lockfile written to`
     snapshot_report <- ci_parse_snapshot_report_packages(
-      utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE)),
+      utils::capture.output(renv::snapshot(lockfile = lockfile, library = lib, prompt = FALSE)),
       snapshot = TRUE
     )
 

--- a/R/update.R
+++ b/R/update.R
@@ -27,7 +27,7 @@ ci_package_update_check <- function(lib = lib) {
     # it up by removing the header (that starts before the `# CRAN` signifier)
     # and the footer that starts with ` - Lockfile written to`
     snapshot_report <- ci_parse_snapshot_report(
-      utils::capture.output(renv::snapshot(lockfile = lock, prompt = FALSE))
+      utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
     )
 
     # We can detect the number of updated packages via checking the number of
@@ -106,19 +106,19 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
         cat("Updating", length(pkgs), "packages from current CRAN\n")
         install_result <- tryCatch({
-          renv::install(pkgs, prompt = FALSE, rebuild = FALSE, type = "binary")
+          renv::install(pkgs, library = lib, prompt = FALSE, rebuild = FALSE, type = "binary")
           TRUE
         }, error = function(e2) {
           cat("Binary install failed, trying with source allowed:\n")
           cat(conditionMessage(e2), "\n")
-          renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
+          install_result <- renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE)
           TRUE
         })
         cat("::endgroup::\n")
 
         cat("::group::Updating lockfile\n")
         snapshot_report <- ci_parse_snapshot_report(
-          utils::capture.output(renv::snapshot(lockfile = lock, prompt = FALSE))
+          utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
         )
         cat("::endgroup::\n")
         n <- n + sum(startsWith(trimws(snapshot_report), "-"))

--- a/R/update.R
+++ b/R/update.R
@@ -91,9 +91,8 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
 
     if (should_update) {
       cat("Attempt initial package restore check\n")
-      restore_output <- character(0)
       updated <- tryCatch({
-        restore_output <<- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
+        restore_output <- utils::capture.output(renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE), type = "message")
         restore_env <- new.env()
         restore_env$n = 0
         restore_env$report = restore_output
@@ -101,7 +100,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       }, error = function(e) {
         cat("Restore failed:", conditionMessage(e), "\n")
         failmsg <-strsplit(sub("failed to install ", "", conditionMessage(e)), ",")
-        if (length(failmsg) >= 0) {
+        if (length(failmsg) > 0) {
           failed_restore_output <- gsub("\"", "", trimws(failmsg[[1]]))
           n_failed_restore <- length(failed_restore_output)
 
@@ -125,7 +124,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
             cat(conditionMessage(e2), "\n")
             utils::capture.output(renv::install(pkgs, library = lib, prompt = FALSE, rebuild = TRUE), type = "message")
           })
-          n <- n + sum(startsWith(trimws(install_result), "-"))
+          n <- sum(startsWith(trimws(install_result), "-"))
           cat("::endgroup::\n")
 
           cat("::group::Updating lockfile\n")
@@ -139,10 +138,9 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           restore_env
         }
       })
+      n <- n + updated$n
+      the_report <- c(the_report, updated$report)
     }
-
-    n <- n + updated$n
-    the_report <- c(the_report, updated$report)
   }
 
   # Detect any new packages that entered the lesson --------------------

--- a/R/update.R
+++ b/R/update.R
@@ -5,8 +5,8 @@ ci_parse_snapshot_report <- function(snapshot_report) {
   }
   footer <- tryCatch(seq(which(startsWith(trimws(snapshot_report), "- Lockfile")),
   length(snapshot_report)), error = function(e) length(snapshot_report))
-  snapshot_report <- snapshot_report[-c(header, footer)]
-  invisible(snapshot_report)
+  snapshot_report_clean <- snapshot_report[-c(header, footer)]
+  return(snapshot_report_clean)
 }
 
 ci_package_update_check <- function(lib = lib) {
@@ -132,19 +132,18 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
           cat("::endgroup::\n")
 
           cat("::group::Updating lockfile\n")
-          snapshot_report <- ci_parse_snapshot_report(
-            utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE))
-          )
+          snapshot_report <- utils::capture.output(renv::snapshot(lockfile = lock, library = lib, prompt = FALSE), type = "message")
           cat("::endgroup::\n")
 
           restore_env$n = n_installed
           restore_env$report = c(failed_report, install_result, snapshot_report)
+
+          cat("Repaired", restore_env$n, "packages\n")
         }
         restore_env
       })
       n <- n + updated$n
       the_report <- c(the_report, updated$report)
-      cat("Repaired", n, "packages\n")
     }
   }
 

--- a/R/update.R
+++ b/R/update.R
@@ -35,6 +35,7 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
   renv::load()
 
   should_force_renv_init <- as.logical(toupper(force_renv_init))
+  should_update <- as.logical(toupper(update))
   if (should_force_renv_init) {
     cat("Forcing renv initialisation at user request\n")
 
@@ -43,36 +44,40 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
       renv::init(bioconductor = TRUE, profile = profile)
     }
 
-    cat("Forcing initial package restore check\n")
-    restore_result <- tryCatch({
-      renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = TRUE)
-      "success"
-    }, error = function(e) {
-      cat("Restore failed:", conditionMessage(e), "\n")
-      cat("Attempting repair by updating packages to latest CRAN versions\n")
+    if (should_update) {
+      cat("Attempt initial package restore check\n")
+      restore_result <- tryCatch({
+        renv::restore(library = lib, lockfile = lock, prompt = FALSE, rebuild = FALSE)
+        "success"
+      }, error = function(e) {
+        cat("Restore failed:", conditionMessage(e), "\n")
+        cat("::group::Attempting repair by updating packages to latest CRAN versions\n")
 
-      # Force current CRAN (not lockfile snapshots)
-      options(repos = c(CRAN = "https://cloud.r-project.org"))
-      options(pkgType = "binary")  # Prefer binaries
+        # Use CRAN instead of lockfile RSPM snapshots, preferring binaries
+        options(repos = c(CRAN = "https://cloud.r-project.org"))
+        options(pkgType = "binary")
 
-      pkgs <- names(current_lock$Packages)
+        pkgs <- names(current_lock$Packages)
 
-      cat("Updating", length(pkgs), "packages from current CRAN\n")
-      install_result <- tryCatch({
-        renv::install(pkgs, prompt = FALSE, rebuild = FALSE, type = "binary")
-        TRUE
-      }, error = function(e2) {
-        cat("Binary install failed, trying with source allowed:\n")
-        cat(conditionMessage(e2), "\n")
-        renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
-        TRUE
+        cat("Updating", length(pkgs), "packages from current CRAN\n")
+        install_result <- tryCatch({
+          renv::install(pkgs, prompt = FALSE, rebuild = FALSE, type = "binary")
+          TRUE
+        }, error = function(e2) {
+          cat("Binary install failed, trying with source allowed:\n")
+          cat(conditionMessage(e2), "\n")
+          renv::install(pkgs, prompt = FALSE, rebuild = TRUE)
+          TRUE
+        })
+        cat("::endgroup::\n")
+
+        cat("::group::Updating lockfile\n")
+        renv::snapshot(prompt = FALSE)
+        cat("::endgroup::\n")
+
+        "repaired"
       })
-
-      cat("Updating lockfile\n")
-      renv::snapshot(prompt = FALSE)
-
-      "repaired"
-    })
+    }
   }
 
   # Detect any new packages that entered the lesson --------------------
@@ -140,7 +145,6 @@ ci_update <- function(profile = 'lesson-requirements', update = 'true', force_re
   cat("::endgroup::\n")
 
   # Check for updates to packages --------------------------------------
-  should_update <- as.logical(toupper(update))
   if (should_update) {
     cat("::group::Applying Updates\n")
     updates <- renv::update(library = lib, check = TRUE)

--- a/R/update.R
+++ b/R/update.R
@@ -10,7 +10,7 @@ ci_parse_snapshot_report <- function(snapshot_report) {
 }
 
 ci_package_update_check <- function(lib = lib) {
-  report_env = env()
+  report_env = new.env()
 
   cat("::group::CI Package Update Check\n")
   updates <- renv::update(library = lib, check = TRUE)


### PR DESCRIPTION
This PR adds support to the force option to attempt an initial restore and package update/install if it fails.

This is typically the case when a new R version is released and a lockfile is out of date. As an example, R 4.6 dropped support for C++ 11 and many packages required updates. If a lockfile has an old version of a package (e.g. base64enc 0.1-3) this will fail to restore/hydrate from a lockfile. Instead, we need to detect that the restore failed, and to do a full update of lockfile packages to ensure everything is up to date.
